### PR TITLE
Implement Functionality to use all existing queries within the mock API

### DIFF
--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		9C2C775F24E1EE9E006EF13C /* OktaAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 9C2C775E24E1EE9E006EF13C /* OktaAuth */; };
 		9C9A98E124E4EF3C007FC7DA /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E024E4EF3C007FC7DA /* Queries.swift */; };
 		9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */; };
+		9C9A98E624E506A6007FC7DA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E524E506A6007FC7DA /* User.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +65,7 @@
 		46C2BC9124D432F90077E49D /* ProfileTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabBarViewController.swift; sourceTree = "<group>"; };
 		9C9A98E024E4EF3C007FC7DA /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
 		9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
+		9C9A98E524E506A6007FC7DA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -167,6 +169,7 @@
 		466C4272249A8748007D033E /* labs-ios-starter */ = {
 			isa = PBXGroup;
 			children = (
+				9C9A98E424E5068B007FC7DA /* Models */,
 				9C9A98DF24E4E22F007FC7DA /* Networking */,
 				13A4A7D324E1F384005326F9 /* Storyboards */,
 				13A4A7D724E1F8DE005326F9 /* View Controllers */,
@@ -230,6 +233,14 @@
 				9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		9C9A98E424E5068B007FC7DA /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A98E524E506A6007FC7DA /* User.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -328,6 +339,7 @@
 				13A4A7D524E1F8CF005326F9 /* DashboardViewController.swift in Sources */,
 				46C2BC9224D432F90077E49D /* ProfileTabBarViewController.swift in Sources */,
 				463AD24324CF275900447BB8 /* ProfileDetailViewController.swift in Sources */,
+				9C9A98E624E506A6007FC7DA /* User.swift in Sources */,
 				13A4A7E224E2034F005326F9 /* DashboardCollectionViewCell.swift in Sources */,
 				46BEB4E524C98CDC00FE0CD1 /* LoginViewController.swift in Sources */,
 				466C4276249A8748007D033E /* SceneDelegate.swift in Sources */,

--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		9C9A98E624E506A6007FC7DA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E524E506A6007FC7DA /* User.swift */; };
 		9C9A98E824E5078B007FC7DA /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E724E5078B007FC7DA /* Property.swift */; };
 		9C9A98EA24E508BE007FC7DA /* Pickup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E924E508BE007FC7DA /* Pickup.swift */; };
+		9C9A98EC24E509B7007FC7DA /* ImpactStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98EB24E509B7007FC7DA /* ImpactStats.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +71,7 @@
 		9C9A98E524E506A6007FC7DA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		9C9A98E724E5078B007FC7DA /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		9C9A98E924E508BE007FC7DA /* Pickup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pickup.swift; sourceTree = "<group>"; };
+		9C9A98EB24E509B7007FC7DA /* ImpactStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpactStats.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -245,6 +247,7 @@
 				9C9A98E524E506A6007FC7DA /* User.swift */,
 				9C9A98E724E5078B007FC7DA /* Property.swift */,
 				9C9A98E924E508BE007FC7DA /* Pickup.swift */,
+				9C9A98EB24E509B7007FC7DA /* ImpactStats.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -335,6 +338,7 @@
 				46BF10BE24D388FF001C6753 /* UIViewController+SimpleAlert.swift in Sources */,
 				9C9A98E824E5078B007FC7DA /* Property.swift in Sources */,
 				46BEB4E724C98D8900FE0CD1 /* Notifications.swift in Sources */,
+				9C9A98EC24E509B7007FC7DA /* ImpactStats.swift in Sources */,
 				9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */,
 				13A4A7E924E24A8B005326F9 /* DashboardLayout.swift in Sources */,
 				46BEB4E124C9828800FE0CD1 /* Profile.swift in Sources */,

--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9C9A98E124E4EF3C007FC7DA /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E024E4EF3C007FC7DA /* Queries.swift */; };
 		9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */; };
 		9C9A98E624E506A6007FC7DA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E524E506A6007FC7DA /* User.swift */; };
+		9C9A98E824E5078B007FC7DA /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E724E5078B007FC7DA /* Property.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -66,6 +67,7 @@
 		9C9A98E024E4EF3C007FC7DA /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
 		9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
 		9C9A98E524E506A6007FC7DA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		9C9A98E724E5078B007FC7DA /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -239,6 +241,7 @@
 			isa = PBXGroup;
 			children = (
 				9C9A98E524E506A6007FC7DA /* User.swift */,
+				9C9A98E724E5078B007FC7DA /* Property.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -327,6 +330,7 @@
 			files = (
 				46BEB4EE24C98ECC00FE0CD1 /* ProfileController.swift in Sources */,
 				46BF10BE24D388FF001C6753 /* UIViewController+SimpleAlert.swift in Sources */,
+				9C9A98E824E5078B007FC7DA /* Property.swift in Sources */,
 				46BEB4E724C98D8900FE0CD1 /* Notifications.swift in Sources */,
 				9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */,
 				13A4A7E924E24A8B005326F9 /* DashboardLayout.swift in Sources */,

--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		46BF10BE24D388FF001C6753 /* UIViewController+SimpleAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BF10BD24D388FF001C6753 /* UIViewController+SimpleAlert.swift */; };
 		46C2BC9224D432F90077E49D /* ProfileTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C2BC9124D432F90077E49D /* ProfileTabBarViewController.swift */; };
 		9C2C775F24E1EE9E006EF13C /* OktaAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 9C2C775E24E1EE9E006EF13C /* OktaAuth */; };
+		9C9A98E124E4EF3C007FC7DA /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E024E4EF3C007FC7DA /* Queries.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +61,7 @@
 		46BEB4F024C98F0D00FE0CD1 /* Profiles.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Profiles.storyboard; sourceTree = "<group>"; };
 		46BF10BD24D388FF001C6753 /* UIViewController+SimpleAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+SimpleAlert.swift"; sourceTree = "<group>"; };
 		46C2BC9124D432F90077E49D /* ProfileTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabBarViewController.swift; sourceTree = "<group>"; };
+		9C9A98E024E4EF3C007FC7DA /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 		466C4272249A8748007D033E /* labs-ios-starter */ = {
 			isa = PBXGroup;
 			children = (
+				9C9A98DF24E4E22F007FC7DA /* Networking */,
 				13A4A7D324E1F384005326F9 /* Storyboards */,
 				13A4A7D724E1F8DE005326F9 /* View Controllers */,
 				13A4A7E324E20353005326F9 /* Views */,
@@ -216,6 +219,14 @@
 				46BEB4F024C98F0D00FE0CD1 /* Profiles.storyboard */,
 			);
 			path = Profiles;
+			sourceTree = "<group>";
+		};
+		9C9A98DF24E4E22F007FC7DA /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				9C9A98E024E4EF3C007FC7DA /* Queries.swift */,
+			);
+			path = Networking;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -306,6 +317,7 @@
 				13A4A7E924E24A8B005326F9 /* DashboardLayout.swift in Sources */,
 				46BEB4E124C9828800FE0CD1 /* Profile.swift in Sources */,
 				46BEB4E924C98DAF00FE0CD1 /* ProfileListViewController.swift in Sources */,
+				9C9A98E124E4EF3C007FC7DA /* Queries.swift in Sources */,
 				463AD24524CF2CDB00447BB8 /* AddProfileViewController.swift in Sources */,
 				13A4A7DE24E1FB1E005326F9 /* HelperExtensions.swift in Sources */,
 				466C4274249A8748007D033E /* AppDelegate.swift in Sources */,

--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */; };
 		9C9A98E624E506A6007FC7DA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E524E506A6007FC7DA /* User.swift */; };
 		9C9A98E824E5078B007FC7DA /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E724E5078B007FC7DA /* Property.swift */; };
+		9C9A98EA24E508BE007FC7DA /* Pickup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E924E508BE007FC7DA /* Pickup.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
 		9C9A98E524E506A6007FC7DA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		9C9A98E724E5078B007FC7DA /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
+		9C9A98E924E508BE007FC7DA /* Pickup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pickup.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -242,6 +244,7 @@
 			children = (
 				9C9A98E524E506A6007FC7DA /* User.swift */,
 				9C9A98E724E5078B007FC7DA /* Property.swift */,
+				9C9A98E924E508BE007FC7DA /* Pickup.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -347,6 +350,7 @@
 				13A4A7E224E2034F005326F9 /* DashboardCollectionViewCell.swift in Sources */,
 				46BEB4E524C98CDC00FE0CD1 /* LoginViewController.swift in Sources */,
 				466C4276249A8748007D033E /* SceneDelegate.swift in Sources */,
+				9C9A98EA24E508BE007FC7DA /* Pickup.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		46C2BC9224D432F90077E49D /* ProfileTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C2BC9124D432F90077E49D /* ProfileTabBarViewController.swift */; };
 		9C2C775F24E1EE9E006EF13C /* OktaAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 9C2C775E24E1EE9E006EF13C /* OktaAuth */; };
 		9C9A98E124E4EF3C007FC7DA /* Queries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E024E4EF3C007FC7DA /* Queries.swift */; };
+		9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,6 +63,7 @@
 		46BF10BD24D388FF001C6753 /* UIViewController+SimpleAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+SimpleAlert.swift"; sourceTree = "<group>"; };
 		46C2BC9124D432F90077E49D /* ProfileTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTabBarViewController.swift; sourceTree = "<group>"; };
 		9C9A98E024E4EF3C007FC7DA /* Queries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queries.swift; sourceTree = "<group>"; };
+		9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,6 +227,7 @@
 			isa = PBXGroup;
 			children = (
 				9C9A98E024E4EF3C007FC7DA /* Queries.swift */,
+				9C9A98E224E4F0D3007FC7DA /* NetworkController.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -314,6 +317,7 @@
 				46BEB4EE24C98ECC00FE0CD1 /* ProfileController.swift in Sources */,
 				46BF10BE24D388FF001C6753 /* UIViewController+SimpleAlert.swift in Sources */,
 				46BEB4E724C98D8900FE0CD1 /* Notifications.swift in Sources */,
+				9C9A98E324E4F0D3007FC7DA /* NetworkController.swift in Sources */,
 				13A4A7E924E24A8B005326F9 /* DashboardLayout.swift in Sources */,
 				46BEB4E124C9828800FE0CD1 /* Profile.swift in Sources */,
 				46BEB4E924C98DAF00FE0CD1 /* ProfileListViewController.swift in Sources */,

--- a/labs-ios-starter/Models/ImpactStats.swift
+++ b/labs-ios-starter/Models/ImpactStats.swift
@@ -1,0 +1,26 @@
+//
+//  ImpactStats.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/13/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class ImpactStats {
+    
+    let id: Int
+    let soapRecycled, linensRecycled, bottlesRecycled, paperRecycled, peopleServed, womenEmployed: Int?
+    
+    init(id: Int, soapRecycled: Int?, linensRecycled: Int?, bottlesRecycled: Int?, paperRecycled: Int?, peopleServed: Int?, womenEmployed: Int?) {
+        self.id = id
+        self.soapRecycled = soapRecycled
+        self.linensRecycled = linensRecycled
+        self.bottlesRecycled = bottlesRecycled
+        self.paperRecycled = paperRecycled
+        self.peopleServed = peopleServed
+        self.womenEmployed = womenEmployed
+    }
+    
+}

--- a/labs-ios-starter/Models/Pickup.swift
+++ b/labs-ios-starter/Models/Pickup.swift
@@ -1,0 +1,28 @@
+//
+//  Pickup.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/13/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class Pickup {
+    
+    let id: Int
+    let confirmationCode, readyDate, pickupDate, notes: String
+    let collectoinType: String
+    var status: String
+    
+    internal init(id: Int, confirmationCode: String, readyDate: String, pickupDate: String, notes: String, collectoinType: String, status: String) {
+        self.id = id
+        self.confirmationCode = confirmationCode
+        self.readyDate = readyDate
+        self.pickupDate = pickupDate
+        self.notes = notes
+        self.collectoinType = collectoinType
+        self.status = status
+    }
+    
+}

--- a/labs-ios-starter/Models/Pickup.swift
+++ b/labs-ios-starter/Models/Pickup.swift
@@ -15,7 +15,7 @@ class Pickup {
     let collectoinType: String
     var status: String
     
-    internal init(id: Int, confirmationCode: String, readyDate: String, pickupDate: String, notes: String, collectoinType: String, status: String) {
+    init(id: Int, confirmationCode: String, readyDate: String, pickupDate: String, notes: String, collectoinType: String, status: String) {
         self.id = id
         self.confirmationCode = confirmationCode
         self.readyDate = readyDate

--- a/labs-ios-starter/Models/Property.swift
+++ b/labs-ios-starter/Models/Property.swift
@@ -1,0 +1,30 @@
+//
+//  Property.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/13/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class Property {
+    
+    let id: Int
+    let rooms: Int
+    var name, propertyType: String
+    var phone, billingAddress, shippingAddress, coordinates, shippingNote, notes: String?
+    
+    init(id: Int, rooms: Int, name: String, propertyType: String, phone: String? = nil, billingAddress: String? = nil, shippingAddress: String? = nil, coordinates: String? = nil, shippingNote: String? = nil, notes: String? = nil) {
+        self.id = id
+        self.rooms = rooms
+        self.name = name
+        self.propertyType = propertyType
+        self.phone = phone
+        self.billingAddress = billingAddress
+        self.shippingAddress = shippingAddress
+        self.coordinates = coordinates
+        self.shippingNote = shippingNote
+        self.notes = notes
+    }
+}

--- a/labs-ios-starter/Models/User.swift
+++ b/labs-ios-starter/Models/User.swift
@@ -1,0 +1,30 @@
+//
+//  User.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/13/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class User {
+    
+    let id: Int
+    var firstName, lastName, email: String
+    var middleName, title, company, phone, skype, address: String?
+    
+    init(id: Int, firstName: String, lastName: String, email: String, middleName: String? = nil, title: String? = nil, company: String? = nil, phone: String? = nil, skype: String? = nil, address: String? = nil) {
+        self.id = id
+        self.firstName = firstName
+        self.lastName = lastName
+        self.email = email
+        self.middleName = middleName
+        self.title = title
+        self.company = company
+        self.phone = phone
+        self.skype = skype
+        self.address = address
+    }
+    
+}

--- a/labs-ios-starter/Networking/NetworkController.swift
+++ b/labs-ios-starter/Networking/NetworkController.swift
@@ -1,0 +1,44 @@
+//
+//  NetworkController.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/12/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class BackendController {
+    private let apiURL: URL = URL(string: "ecosoap-placeholder.herokuapp.com/graphiql")!
+    
+    private var encoder = JSONEncoder()
+    private var decoder = JSONDecoder()
+    
+    func queryAPI(completion: @escaping (String, Any?) -> Void) {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        request.httpBody = try! JSONSerialization.data(withJSONObject: ["query":Queries.statsById], options: [])
+        
+        URLSession.shared.dataTask(with: request) { data, _, error in
+            if let _ = error {
+                completion("No bueno", nil)
+                return
+            }
+            
+            guard let data = data else {
+                completion("No Data", nil)
+                return
+            }
+            
+            do {
+                let dict = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+                completion("We got stuff", dict)
+            } catch let error {
+                completion("No cigar", nil)
+            }
+        }.resume()
+        
+    }
+}

--- a/labs-ios-starter/Networking/NetworkController.swift
+++ b/labs-ios-starter/Networking/NetworkController.swift
@@ -9,34 +9,34 @@
 import Foundation
 
 class BackendController {
-    private let apiURL: URL = URL(string: "ecosoap-placeholder.herokuapp.com/graphiql")!
+    private let apiURL: URL = URL(string: "https://ecosoap-placeholder.herokuapp.com/graphql")!
     
     private var encoder = JSONEncoder()
     private var decoder = JSONDecoder()
     
-    func queryAPI(completion: @escaping (String, Any?) -> Void) {
+    func queryAPI(query: String, completion: @escaping (String, Any?, Error?) -> Void) {
         var request = URLRequest(url: apiURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        request.httpBody = try! JSONSerialization.data(withJSONObject: ["query":Queries.statsById], options: [])
+        request.httpBody = try! JSONSerialization.data(withJSONObject: ["query":query], options: [])
         
         URLSession.shared.dataTask(with: request) { data, _, error in
             if let _ = error {
-                completion("No bueno", nil)
+                completion("No bueno", nil, error)
                 return
             }
             
             guard let data = data else {
-                completion("No Data", nil)
+                completion("No Data", nil, nil)
                 return
             }
             
             do {
                 let dict = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-                completion("We got stuff", dict)
+                completion("We got stuff", dict, nil)
             } catch let error {
-                completion("No cigar", nil)
+                completion("No cigar", nil, error)
             }
         }.resume()
         

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -9,20 +9,5 @@
 import Foundation
 
 class Queries {
-    static let statsById = """
-    query {
-      impactStatsByPropertyId(input: {
-        propertyId: 11
-      }) {
-        impactStats {
-          soapRecycled
-          linensRecycled
-          bottlesRecycled
-          paperRecycled
-          peopleServed
-          womenEmployed
-        }
-      }
-    }
-    """
+    static let statsById = "{propertyById(input: {propertyId: 2}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -71,4 +71,31 @@ class Queries {
         }
         """
     }
+
+    static func propertyById(propertyId: Int = 11) -> String {
+        return """
+        {
+          propertyById(input: {
+            propertyId: \(propertyId)
+          }) {
+            property {
+              id,
+                name,
+                rooms,
+                phone,
+                billingAddress,
+                shippingAddress,
+                coordinates,
+                shippingNote,
+                notes,
+              users {
+                id,
+                firstName,
+                lastName
+              }
+            }
+          }
+        }
+        """
+    }
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -10,4 +10,28 @@ import Foundation
 
 class Queries {
     static let statsById = "{propertyById(input: {propertyId: 11}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
+    static let propertiesByUserId = """
+{
+  propertiesByUserId(input: {
+    userId: 11
+  }) {
+    properties {
+      id,
+        name,
+        rooms,
+        phone,
+        billingAddress,
+        shippingAddress,
+        coordinates,
+        shippingNote,
+        notes,
+      users {
+        id,
+        firstName,
+        lastName
+      }
+    }
+  }
+}
+"""
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -34,4 +34,36 @@ class Queries {
   }
 }
 """
+    static let userById = """
+{
+  userById(input: {
+    userId: 1
+  }) {
+    user {
+      id,
+      firstName,
+      middleName,
+      lastName,
+      title,
+      company,
+      email,
+      phone,
+      skype,
+      address,
+      signupTime,
+      properties {
+        id,
+        name,
+        rooms,
+        phone,
+        billingAddress,
+        shippingAddress,
+        coordinates,
+        shippingNote,
+        notes
+      }
+    }
+  }
+}
+"""
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -98,4 +98,23 @@ class Queries {
         }
         """
     }
+
+    static func impactStatsByPropertyId(propertyId: Int = 11) -> String {
+        return """
+        query {
+          impactStatsByPropertyId(input: {
+            propertyId: \(propertyId)
+          }) {
+            impactStats {
+              soapRecycled
+              linensRecycled
+              bottlesRecycled
+              paperRecycled
+              peopleServed
+              womenEmployed
+            }
+          }
+        }
+        """
+    }
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -1,0 +1,28 @@
+//
+//  Queries.swift
+//  labs-ios-starter
+//
+//  Created by Karen Rodriguez on 8/12/20.
+//  Copyright © 2020 Spencer Curtis. All rights reserved.
+//
+
+import Foundation
+
+class Queries {
+    static let statsById = """
+    query {
+      impactStatsByPropertyId(input: {
+        propertyId: 11
+      }) {
+        impactStats {
+          soapRecycled
+          linensRecycled
+          bottlesRecycled
+          paperRecycled
+          peopleServed
+          womenEmployed
+        }
+      }
+    }
+    """
+}

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -9,61 +9,66 @@
 import Foundation
 
 class Queries {
-    static let statsById = "{propertyById(input: {propertyId: 11}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
-    static let propertiesByUserId = """
-{
-  propertiesByUserId(input: {
-    userId: 11
-  }) {
-    properties {
-      id,
-        name,
-        rooms,
-        phone,
-        billingAddress,
-        shippingAddress,
-        coordinates,
-        shippingNote,
-        notes,
-      users {
-        id,
-        firstName,
-        lastName
-      }
+    
+    static func statsById(propertyId: Int = 11) -> String {
+        return "{propertyById(input: {propertyId: \(propertyId)}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
     }
-  }
-}
-"""
-    static let userById = """
-{
-  userById(input: {
-    userId: 1
-  }) {
-    user {
-      id,
-      firstName,
-      middleName,
-      lastName,
-      title,
-      company,
-      email,
-      phone,
-      skype,
-      address,
-      signupTime,
-      properties {
-        id,
-        name,
-        rooms,
-        phone,
-        billingAddress,
-        shippingAddress,
-        coordinates,
-        shippingNote,
-        notes
-      }
+    
+    static func propertiesByUserId(userId: Int = 11) -> String {
+        return """
+        {
+        propertiesByUserId(input: { userId: \(userId) }) {
+            properties {
+                id,
+                name,
+                rooms,
+                phone,
+                billingAddress,
+                shippingAddress,
+                coordinates,
+                shippingNote,
+                notes,
+            users {
+                id,
+                firstName,
+                lastName
+              }
+            }
+          }
+        }
+        """
     }
-  }
-}
-"""
+
+    static func userById(userId: Int = 1) -> String {
+        return """
+        {
+          userById(input: { userId: \(userId) }) {
+            user {
+              id,
+              firstName,
+              middleName,
+              lastName,
+              title,
+              company,
+              email,
+              phone,
+              skype,
+              address,
+              signupTime,
+              properties {
+                id,
+                name,
+                rooms,
+                phone,
+                billingAddress,
+                shippingAddress,
+                coordinates,
+                shippingNote,
+                notes
+              }
+            }
+          }
+        }
+        """
+    }
 }

--- a/labs-ios-starter/Networking/Queries.swift
+++ b/labs-ios-starter/Networking/Queries.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 class Queries {
-    static let statsById = "{propertyById(input: {propertyId: 2}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
+    static let statsById = "{propertyById(input: {propertyId: 11}) {property {id,name,rooms,phone,billingAddress,shippingAddress,coordinates,shippingNote,notes,users {id,firstName,lastName}}}}"
 }


### PR DESCRIPTION
### Summary
Given the nature of GraphQL, the meat of the code is in building the queries. This allows for a rather light network controller. Same endpoint, all that changes is the body.

Current functionality will let us use all current queries. Next step is to properly decode the response body.

### List of Changes
- Create Network Controller class.
- Create function within network controller to dynamically accept queries in the forms of strings and ping the API.
- Create Queries class with functions that return the queries as string.
- Create base model classes for decoding JSON Response from server.